### PR TITLE
update the fedora image download url to pioneer verion 1.3

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/pioneer/getting-started/download.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/pioneer/getting-started/download.md
@@ -33,7 +33,7 @@ sidebar_position: 30
 
 ### 镜像
 
-- [Fedora 38 for Milk-V Pioneer](https://drive.google.com/file/d/1IjxeKiwtyDTmc2YGbn7yvpbCx0B1kkBh/view?usp=sharing)
+- [Fedora 38 for Milk-V Pioneer](https://drive.google.com/file/d/1-tYHNXjX6oekNorOGlWb_Az2nVOoey6y/view?usp=sharing)
 
 ### 工具
 


### PR DESCRIPTION
update the fedora image download url to pioneer verion 1.3，the old url can‘t boot。