### PR TITLE
Fixed locale in Debian image links in boot.md

### DIFF
--- a/docs/mars/compute-module/boot.md
+++ b/docs/mars/compute-module/boot.md
@@ -26,7 +26,7 @@ Taking the Raspberry Pi CM4 IO Board as an example, we will introduce how to bur
 
 ### Download image and burning tools
 
-- Download the Debian system image: [Official Image](https://milkv.io/zh/docs/mars/compute-module/resources/images)
+- Download the Debian system image: [Official Image](https://milkv.io/docs/mars/compute-module/resources/images)
 - Download the eMMC image burning tool: [UsbFlashTool](https://github.com/milkv-mars/mars-tools/blob/main/Mars-UsbFlashTool-v2.4-Windows.zip)
 
 ### Install driver for the burning tool
@@ -150,7 +150,7 @@ The Lite version does not come with eMMC and needs to burn the firmware to the S
 
 ### Download image and burning tools
 
-- Download the Debian system image: [Official Image](https://milkv.io/zh/docs/mars/compute-module/resources/images)
+- Download the Debian system image: [Official Image](https://milkv.io/docs/mars/compute-module/resources/images)
 - Download the burning tool: [balenaEtcher](https://etcher.balena.io/) or [Rufus](https://rufus.ie/en/)
 
 ### Burn image


### PR DESCRIPTION
Links to Debian images directed to the Chinese page, from the English docs, when an English page exists