### PR TITLE
Fixed the docker command to run the container

### DIFF
--- a/docs/duo/getting-started/buildroot-sdk.md
+++ b/docs/duo/getting-started/buildroot-sdk.md
@@ -194,7 +194,7 @@ cd duo-buildroot-sdk
 ### Pull the Docker image and run
 
 ```bash
-docker run --privileged -itd --name duodocker -v $(pwd):/home/work milkvtech/milkv-duo:latest /bin/bash
+docker run --privileged -itd --name duodocker -v "$(pwd)":/home/work milkvtech/milkv-duo:latest /bin/bash
 ```
 
 Description of some parameters in the command:


### PR DESCRIPTION
The pwd command wasn't properly formated and needed to look like this "$(pwd)", otherwise docker will complain about bad formating and not run, as the path is not passed along properly