### PR TITLE
docs: meles: point download link to RevyOS docs

### DIFF
--- a/docs/meles/resources-download/image.md
+++ b/docs/meles/resources-download/image.md
@@ -5,14 +5,30 @@ sidebar_position: 10
 
 # Official Image
 
+:::tip
+The images listed below might not be up-to-date.
+
+Please check [RevyOS Docs](https://docs.revyos.dev/en/docs/Installation/intro/) for latest images.
+:::
+
 ### v2024-0417
 
 Link:[Meles Image](https://github.com/milkv-meles/meles-images/releases/tag/v2024-0417).
 
-### v2024-0601
+### 20240720
 
-Link:[Meles Image](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20240601/).
+:::note
+This is the last version using Linux Kernel 5.10.
+:::
 
-### v2024-0720
+Link: [Meles Image](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20240720/)。
 
-Link:[Meles Image](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20240720/).
+### 20251226
+
+:::note
+For this version and later versions, Linux kernel 6.6 is used.
+
+You must upgrade the firmware inside the SPI Flash before flashing the OS image.
+:::
+
+Link: [Meles Image](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20251226)

--- a/i18n/zh/docusaurus-plugin-content-docs/current/meles/resources-download/image.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/meles/resources-download/image.md
@@ -5,35 +5,30 @@ sidebar_position: 10
 
 # Official Image
 
+:::tip
+下方所列出的镜像版本可能不是最新。
+
+请访问 [RevyOS Docs](https://docs.revyos.dev/docs/Installation/intro/) 以获取最新版本镜像相关信息。
+:::
+
 ### v2024-0417
 
 镜像链接：[Meles 镜像](https://github.com/milkv-meles/meles-images/releases/tag/v2024-0417)。
 
-### v2024-0601
+### 20240720
 
-镜像链接：[Meles 镜像](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20240601/)。
-
-### v2024-0720
+:::note
+这是最后一个使用 Linux kernel 5.10 的版本。
+:::
 
 镜像链接：[Meles 镜像](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20240720/)。
 
-### v2024-1229
+### 20251226
 
-镜像链接：[Meles 镜像](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20241229/)。
+:::note
+此版本起，Linux kernel 更新至 6.6。
 
-### v2025-0110
+刷写系统前，请务必先更新 SPI Flash 中的固件。
+:::
 
-镜像链接：[Meles 镜像](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20250110/)。
-
-### v2025-0123
-
-镜像链接：[Meles 镜像](https://fast-mirror.isrc.ac.cn/revyos/extra/images/meles/20250123/)。
-
-### v2025-0323
-
-镜像链接：[Meles 镜像](https://fast-mirror.isrc.ac.cn/revyos/extra/images/meles/20250323/)。
-
-### v2025-0420
-
-镜像链接：[Meles 镜像](https://fast-mirror.isrc.ac.cn/revyos/extra/images/meles/20250420/)。
-
+镜像链接：[Meles 镜像](https://mirror.iscas.ac.cn/revyos/extra/images/meles/20251226)


### PR DESCRIPTION
I assume the download links are not regularly updated.

So let's just point them to RevyOS docs, those will be updated when a new image come out.

Stale links are removed, and some extra notes are added too.